### PR TITLE
Set custom paramsSerializer for Axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "qs": "^6.6.0",
     "reflect-metadata": "^0.1.13",
     "tsyringe": "^3.0.1"
   }

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -1,4 +1,5 @@
 import Axios, { AxiosInstance } from 'axios'
+import qs from 'qs'
 import { IToken } from './interfaces/Token'
 import { GET, DELETE } from './constants'
 
@@ -14,6 +15,9 @@ export default class Http {
       baseURL: this.host + 'api/v2/storefront',
       headers: {
         'Content-Type': 'application/vnd.api+json'
+      },
+      paramsSerializer: (params) => {
+        return qs.stringify(params, { arrayFormat: 'brackets' })
       }
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3195,6 +3195,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+qs@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
+  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"


### PR DESCRIPTION
Makes Axios convert `{params: {filter: {somefilter: 'somevalue'}}}` to query `filter[somefilter]=somevalue` instead of serialized JSON.