### PR TITLE
Fix token persistency across requests

### DIFF
--- a/src/endpoints/Account.ts
+++ b/src/endpoints/Account.ts
@@ -7,27 +7,22 @@ import { Routes } from '../routes'
 
 export default class Account extends Http {
   public async accountInfo(token: IToken, params: IQuery = {}): Promise<IAccount> {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.accountPath(), params)
+    return await this.spreeResponse(GET, Routes.accountPath(), token, params)
   }
 
   public async creditCardsList(token: IToken, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.accountCreditCardsPath(), params)
+    return await this.spreeResponse(GET, Routes.accountCreditCardsPath(), token, params)
   }
 
   public async defaultCreditCard(token: IToken, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.accountDefaultCreditCardPath(), params)
+    return await this.spreeResponse(GET, Routes.accountDefaultCreditCardPath(), token, params)
   }
 
   public async completedOrdersList(token: IToken, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.accountCompletedOrdersPath(), params)
+    return await this.spreeResponse(GET, Routes.accountCompletedOrdersPath(), token, params)
   }
 
   public async completedOrder(token: IToken, orderNumber: string, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.accountCompletedOrderPath(orderNumber), params)
+    return await this.spreeResponse(GET, Routes.accountCompletedOrderPath(orderNumber), token, params)
   }
 }

--- a/src/endpoints/Cart.ts
+++ b/src/endpoints/Cart.ts
@@ -8,42 +8,34 @@ import { Routes } from '../routes'
 
 export default class Cart extends Http implements CartClass {
   public async show(token: IToken, params: IQuery = {}): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.cartPath(), params)
+    return await this.spreeResponse(GET, Routes.cartPath(), token, params)
   }
 
   public async create(token?: IToken, params: IQuery = {}): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(POST, Routes.cartPath(), params)
+    return await this.spreeResponse(POST, Routes.cartPath(), token, params)
   }
 
   public async addItem(token: IToken, params: AddItem): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(POST, Routes.cartAddItemPath(), params)
+    return await this.spreeResponse(POST, Routes.cartAddItemPath(), token, params)
   }
 
   public async removeItem(token: IToken, id: string, params: IQuery = {}): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(DELETE, Routes.cartRemoveItemPath(id), params)
+    return await this.spreeResponse(DELETE, Routes.cartRemoveItemPath(id), token, params)
   }
 
   public async emptyCart(token: IToken, params: IQuery = {}): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.cartEmptyPath(), params)
+    return await this.spreeResponse(PATCH, Routes.cartEmptyPath(), token, params)
   }
 
   public async setQuantity(token: IToken, params: SetQuantity): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.cartSetItemQuantity(), params)
+    return await this.spreeResponse(PATCH, Routes.cartSetItemQuantity(), token, params)
   }
 
   public async applyCouponCode(token: IToken, params: CouponCode): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.cartApplyCodePath(), params)
+    return await this.spreeResponse(PATCH, Routes.cartApplyCodePath(), token, params)
   }
 
   public async removeCouponCode(token: IToken, code: string, params: IQuery = {}): Promise<IOrder> {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.cartRemoveCodePath(code), params)
+    return await this.spreeResponse(PATCH, Routes.cartRemoveCodePath(code), token, params)
   }
 }

--- a/src/endpoints/Checkout.ts
+++ b/src/endpoints/Checkout.ts
@@ -7,42 +7,34 @@ import { Routes } from '../routes'
 
 export default class Checkout extends Http implements CheckoutClass {
   public async orderNext(token: IToken, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.checkoutNextPath(), params)
+    return await this.spreeResponse(PATCH, Routes.checkoutNextPath(), token, params)
   }
 
   public async orderUpdate(token: IToken, params: NestedAttributes) {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.checkoutPath(), params)
+    return await this.spreeResponse(PATCH, Routes.checkoutPath(), token, params)
   }
 
   public async advance(token: IToken, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.checkoutAdvancePath(), params)
+    return await this.spreeResponse(PATCH, Routes.checkoutAdvancePath(), token, params)
   }
 
   public async complete(token: IToken, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(PATCH, Routes.checkoutCompletePath(), params)
+    return await this.spreeResponse(PATCH, Routes.checkoutCompletePath(), token, params)
   }
 
   public async addStoreCredits(token: IToken, params: AddStoreCredit) {
-    this.spreeTokens = token
-    return await this.spreeResponse(POST, Routes.checkoutAddStoreCreditsPath(), params)
+    return await this.spreeResponse(POST, Routes.checkoutAddStoreCreditsPath(), token, params)
   }
 
   public async removeStoreCredits(token: IToken, params: IQuery = {}) {
-    this.spreeTokens = token
-    return await this.spreeResponse(POST, Routes.checkoutRemoveStoreCreditsPath(), params)
+    return await this.spreeResponse(POST, Routes.checkoutRemoveStoreCreditsPath(), token, params)
   }
 
   public async paymentMethods(token: IToken) {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.checkoutPaymentMethodsPath())
+    return await this.spreeResponse(GET, Routes.checkoutPaymentMethodsPath(), token)
   }
 
   public async shippingMethods(token: IToken) {
-    this.spreeTokens = token
-    return await this.spreeResponse(GET, Routes.checkoutShippingMethodsPath())
+    return await this.spreeResponse(GET, Routes.checkoutShippingMethodsPath(), token)
   }
 }

--- a/src/endpoints/Countries.ts
+++ b/src/endpoints/Countries.ts
@@ -11,6 +11,6 @@ export default class Countries extends Http implements SimpleEndpoint {
   }
 
   public async show(iso: string, params: IQuery = {}): Promise<ICountry> {
-    return await this.spreeResponse(GET, Routes.countryPath(iso), params)
+    return await this.spreeResponse(GET, Routes.countryPath(iso), {}, params)
   }
 }

--- a/src/endpoints/Order.ts
+++ b/src/endpoints/Order.ts
@@ -7,6 +7,6 @@ import { Routes } from '../routes'
 
 export default class Order extends Http implements OrderClass {
   public async status(orderNumber: string, params: IQuery = {}): Promise<IOrder> {
-    return await this.spreeResponse(GET, Routes.orderStatusPath(orderNumber), params)
+    return await this.spreeResponse(GET, Routes.orderStatusPath(orderNumber), {}, params)
   }
 }

--- a/src/endpoints/Products.ts
+++ b/src/endpoints/Products.ts
@@ -7,10 +7,10 @@ import { Routes } from '../routes'
 
 export default class Products extends Http implements SimpleEndpoint {
   public async list(params: IQuery = {}): Promise<IProducts> {
-    return await this.spreeResponse(GET, Routes.productsPath(), params)
+    return await this.spreeResponse(GET, Routes.productsPath(), {}, params)
   }
 
   public async show(id: string, params: IQuery = {}): Promise<IProduct> {
-    return await this.spreeResponse(GET, Routes.productPath(id), params)
+    return await this.spreeResponse(GET, Routes.productPath(id), {}, params)
   }
 }

--- a/src/endpoints/Taxons.ts
+++ b/src/endpoints/Taxons.ts
@@ -7,10 +7,10 @@ import { Routes } from '../routes'
 
 export default class Taxons extends Http implements SimpleEndpoint {
   public async list(params: IQuery = {}): Promise<ITaxons> {
-    return await this.spreeResponse(GET, Routes.taxonsPath(), params)
+    return await this.spreeResponse(GET, Routes.taxonsPath(), {}, params)
   }
 
   public async show(id: string, params: IQuery = {}): Promise<ITaxon> {
-    return await this.spreeResponse(GET, Routes.taxonPath(id), params)
+    return await this.spreeResponse(GET, Routes.taxonPath(id), {}, params)
   }
 }


### PR DESCRIPTION
Old cart token was returned after clearing session because it was passed to default Axios headers. 